### PR TITLE
Potential fix for code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -19,7 +19,7 @@ def index():
 
     elif author:
         cursor.execute(
-            "SELECT * FROM books WHERE author LIKE '%" + author + "%'"
+            "SELECT * FROM books WHERE author LIKE %s", (f"%{author}%",)
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
Potential fix for [https://github.com/edukkkkation/skills-introduction-to-codeql/security/code-scanning/2](https://github.com/edukkkkation/skills-introduction-to-codeql/security/code-scanning/2)

To fix the vulnerability, we must stop using string concatenation to build the SQL query with user data. The correct and safest solution is to use parameterized queries. The Python DB-API allows executing parameterized SQL using placeholders (`%s` for most connectors, such as MySQLdb or psycopg2) and passing the actual values as a second argument to `cursor.execute()`.  
For `LIKE ... %...%`, this means building the pattern (`%author%`) in Python, and passing it as a parameter.  
The edited section is only lines 22 (and optionally the identical issue on 16 as a followup).

Required changes:
- Change line 22 so the SQL query uses a `LIKE %s` parameter, and pass `f"%{author}%"` as the parameter argument. 
- No import or extra method is needed.
- Only lines 22 (and potentially 16 for consistency/future-proofing) are to be edited per the user's instructions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
